### PR TITLE
Add ppc64le support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ RUN cd /tmp && \
         apt update && \
         apt install -y cmake clang libclang-dev curl unzip && \
         curl -L -O https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-s390_64.zip; \
+    elif [ "$(uname -m)" = "ppc64le" ]; then \
+       apt update && \
+       apt install -y cmake libclang-dev && \
+       curl -L -O https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-ppcle_64.zip; \
     else \
         curl -L -O https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip; \
     fi && \


### PR DESCRIPTION
Created PR to support `ppc64le` architecture. Added condition block for `ppc64le` based on the underlaying architecture it runs on.
