### PR TITLE
Update the pinned openssl version to solve the build issue happening on 3.4

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -3,7 +3,7 @@ ARG UBI_BASE_IMAGE_TAG=latest
 ARG PROTOC_VERSION=29.3
 ARG CONFIG_FILE=config/config.yaml
 ARG TARGETARCH
-ARG OPENSSL_VERSION=3.5.1-7.el9_7
+ARG OPENSSL_VERSION=3.5.5-3.el9_8
 
 ## Rust builder ################################################################
 FROM ${UBI_MINIMAL_BASE_IMAGE}:${UBI_BASE_IMAGE_TAG} AS rust-builder


### PR DESCRIPTION
### Summary
Update OPENSSL_VERSION from 3.5.1-7.el9_7 to 3.5.5-3.el9_8 in Dockerfile.konflux
The previous version is no longer available in UBI9 repos, causing the build to fail

### Test plan

- [ ]     Verify build passes for odh-fms-guardrails-orchestrator-v3-5-ea-1


Backport of PR https://github.com/red-hat-data-services/fms-guardrails-orchestrator/pull/250